### PR TITLE
Release a job's streaming handles before delete-with-files removes its directory

### DIFF
--- a/crates/nzbfast/src/serve/api/queue/payload.rs
+++ b/crates/nzbfast/src/serve/api/queue/payload.rs
@@ -900,6 +900,7 @@ pub(super) fn m_history(
                     to_remove.iter().map(|(_, dir, _, _)| dir.clone()).collect();
                 crate::serve::earlyfile::early_unlink(&early_gone);
                 for (name, dir, filed, tail) in to_remove {
+                    d.hub.release_handles_for_dir(&dir);
                     let outcome = remove_job_files(&dir, &name, filed, &tail);
                     if let FilesGone::Kept(why) = outcome {
                         kept.push((name, dir, why));

--- a/crates/nzbfast/src/serve/daemon_park.rs
+++ b/crates/nzbfast/src/serve/daemon_park.rs
@@ -456,6 +456,7 @@ impl Daemon {
             // The request answered long ago, so a refusal here has no
             // response left to ride back on - same as park's deferred
             // removal, and the notice is how it reaches the user.
+            d.hub.release_handles_for_dir(&dir);
             if let FilesGone::Kept(why) = remove_job_files(&dir, &name, filed, &tail) {
                 // No NZB to offer: the delete handler removed this job's
                 // spool copy when it took the row out of the queue, long
@@ -811,6 +812,7 @@ impl Daemon {
             // request answered - so a refusal here has no response
             // left to ride back on, and the notice is the only way it
             // reaches them at all.
+            self.hub.release_handles_for_dir(&out_dir);
             if let FilesGone::Kept(why) = remove_job_files(&out_dir, &stem, filed, &tail) {
                 // ...and the spool copy becomes the notice's offer to
                 // run it again - but ONLY where `gone_nzb` already
@@ -2100,6 +2102,7 @@ impl CustodyBatch {
         crate::serve::earlyfile::early_unlink(&self.early_gone);
         let mut kept: Vec<(String, std::path::PathBuf, String)> = Vec::new();
         for (name, dir, filed, tail) in self.doomed {
+            d.hub.release_handles_for_dir(&dir);
             if let FilesGone::Kept(why) = remove_job_files(&dir, &name, filed, &tail) {
                 kept.push((name, dir, why));
             }

--- a/crates/nzbfast/src/streamhub.rs
+++ b/crates/nzbfast/src/streamhub.rs
@@ -770,6 +770,41 @@ impl StreamHub {
         }
     }
 
+    /// Drop the post-completion streaming handles whose extractor writes
+    /// into `dir`, so a delete-with-files can actually remove it.
+    ///
+    /// The extractor is deliberately left installed after a job
+    /// completes (post-completion streaming), and the runner clears it
+    /// only when the NEXT job starts - which on an idle daemon is never.
+    /// Until then the extractor graph holds the job's output files OPEN
+    /// (every FileWriter keeps its handle), and on NFS an open handle
+    /// turns unlink into a `.nfs*` silly-rename and the directory
+    /// removal into EBUSY. Every delete arm therefore calls this before
+    /// `remove_job_files`: deleting a job's files and streaming them are
+    /// mutually exclusive intents, so severing the stream for THAT job
+    /// is the request, not a casualty. Matched by directory - the one
+    /// identity the delete arms and the extractor share - so the active
+    /// job's handles go only when it is the active job being deleted.
+    ///
+    /// The seek handle goes first: SeekCtl holds a strong extractor
+    /// reference of its own (see the runner's job-transition clearing),
+    /// so clearing only the extractor slot would leave the graph pinned
+    /// through it.
+    pub fn release_handles_for_dir(&self, dir: &std::path::Path) {
+        {
+            let mut g = self.seek.lock_ok();
+            if g.as_ref().is_some_and(|s| s.extractor.out_dir() == dir) {
+                *g = None;
+            }
+        }
+        {
+            let mut g = self.extractor.lock_ok();
+            if g.as_ref().is_some_and(|(_, ex)| ex.out_dir() == dir) {
+                *g = None;
+            }
+        }
+    }
+
     /// TODO 274: the ACTIVE run's per-file table, when it belongs to
     /// `owner` - same ownership rule as [`Self::extractor_for`], and the
     /// same single-lock owner-check-and-clone, so a job transition can
@@ -1332,5 +1367,32 @@ mod resume_route_tests {
         // minted off a plain counter, so `...nzbfast1` is a strict
         // prefix of `...nzbfast10` through `19` and of `...100` up.
         assert_eq!(h.resume_route_for("SABnzbd_nzo_nzbfast10"), None);
+    }
+
+    #[test]
+    fn a_delete_releases_only_the_directory_it_is_deleting() {
+        let h = StreamHub::default();
+        let dir = std::path::Path::new("/data/usenet/complete/movies/A");
+        let other = std::path::Path::new("/data/usenet/complete/movies/B");
+        let ex = Arc::new(nzbkit::extract::Extractor::new(dir, 1, false));
+        *h.extractor.lock_ok() = Some(("SABnzbd_nzo_nzbfast1".into(), ex));
+
+        // Deleting a DIFFERENT job's directory leaves post-completion
+        // streaming for this one alone.
+        h.release_handles_for_dir(other);
+        assert!(
+            h.extractor.lock_ok().is_some(),
+            "an unrelated delete must not sever the stream"
+        );
+
+        // Deleting THIS job's directory drops the hub's handle: the
+        // extractor graph - and every output file it holds open - now
+        // dies with the last streaming clone instead of living until
+        // the next job happens to start.
+        h.release_handles_for_dir(dir);
+        assert!(
+            h.extractor.lock_ok().is_none(),
+            "the deleted directory's handles must go"
+        );
     }
 }

--- a/crates/nzbkit/src/extract/mod.rs
+++ b/crates/nzbkit/src/extract/mod.rs
@@ -1035,6 +1035,14 @@ impl Extractor {
         Self::with_resume(out_dir, n_slots, enabled, false)
     }
 
+    /// The directory this extractor writes into. A delete-with-files
+    /// asks it whether a still-installed post-completion streaming
+    /// handle is the one pinning the directory it is about to remove
+    /// (see `StreamHub::release_handles_for_dir`).
+    pub fn out_dir(&self) -> &Path {
+        &self.out_dir
+    }
+
     /// §94 A: can this slot's arriving bytes be PLACED rather than
     /// held? True once the slot has classified and, if it mapped, every
     /// parsed entry of it has a resolved base offset - which for a


### PR DESCRIPTION
## What & why

Fixes #71.

A delete-with-files issued after a job completes fails with EBUSY on NFS: the post-completion streaming handles (`streamhub.extractor`, and `seek` which holds its own strong extractor reference) keep the job's output files open until the *next* job starts, which on an idle daemon is never. Sonarr/Radarr delete right after import, so the record goes but the directory stays, with `.nfs*` silly-rename files inside.

Deleting a job's files and streaming them are mutually exclusive intents, so each delete arm now calls `StreamHub::release_handles_for_dir` before `remove_job_files`: it drops the seek and extractor slots when their extractor writes into the directory being removed - matched by `out_dir`, the one identity the delete arms and the extractor share. Seek goes first (it pins the extractor graph on its own, as the runner's job-transition clearing notes). Post-completion streaming for any other job is untouched; the runner's next-job clearing remains the backstop.

Four call sites (queue payload bulk delete, sidecar-drain removal, live-delete park, bulk history sweep) plus a small `Extractor::out_dir()` accessor in nzbkit. Unit test covers both directions: an unrelated directory's delete leaves the installed stream alone; the matching directory's delete drops it.

## Checklist

- [x] `cargo test` passes locally (2816 passed, 0 failed, 13 ignored)
- [x] Commits carry a `Signed-off-by:` line
- [x] For features/larger changes: linked to a discussed issue (#71)